### PR TITLE
add nest-bull

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@
   - [Nest Memcached](https://github.com/nest-cloud/nest-memcached) - A memcached module for Nest framework.
 - Frontend
   - [NestJS CRUD React Admin](https://github.com/FusionWorks/react-admin-nestjsx-crud-dataprovider) - A React Admin data provider for [NextJS CRUD](https://github.com/nestjsx/crud)
+- Scheduling
+  - [Nest Bull](https://github.com/nestjsx/nest-bull) - A Bull module for Nest framework :cow:
 
 ## Runtime
 


### PR DESCRIPTION
I've added a "Scheduling" subgroup under the "Integrations" category. It contains a link to the [nest-bull](https://github.com/nestjsx/nest-bull) packages which is a [Bull](https://optimalbits.github.io/bull/) integration for NestJS.