### PR TITLE
Remove nestjs-grpc-transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@
   - [GoLevelUp NestJS GraphQL Request](https://github.com/golevelup/nestjs/tree/master/packages/graphql-request) - Easily inject and work with GraphQLClient instances from server side NestJS code. Useful for interacting with third party GraphQL APIs
   - [GoLevelUp NestJS Hasura](https://github.com/golevelup/nestjs/tree/master/packages/hasura) - NestJS integrations for working with [Hasura](https://hasura.io/) which provides realtime GraphQL APIs over your Postgres Database
 - Pattern
-  - [Nest GRPC Transport](https://github.com/fresh8/nestjs-grpc-transport) - GRPC transport layer for the NestJS framework.
   - [Nest typeorm paginate](https://github.com/nestjsx/nestjs-typeorm-paginate) - A simple function and interfaces for pagination. 
   - [Nest JSON RPC Transport](https://github.com/Insidexa/nestjs-rpc) - JSON RPC transport layer for the NestJS framework.
 - Editors


### PR DESCRIPTION
Hey! Thx for nice repo. 

Removed lib https://github.com/fresh8/nestjs-grpc-transport (lib is no longer maintaned, and nest now has own official grpc support)