### PR TITLE
Update Suites entry: fix link and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,7 @@
 - ![](https://img.shields.io/github/stars/golevelup/nestjs.svg?style=flat-square) [`@golevelup/ts-jest`](https://www.npmjs.com/package/@golevelup/ts-jest) and [`@golevelup/ts-vitest`](https://www.npmjs.com/package/@golevelup/ts-vitest) - Utilities for making testing NestJS applications easier. Currently supports Jest and Vitest
 - ![](https://img.shields.io/github/stars/omermorad/mockingbird.svg?style=flat-square) [`mockingbird`](https://www.npmjs.com/package/mockingbird) - A library to create typed tests fixtures/mocks using decorators and built-in faker support
 - ![](https://img.shields.io/github/stars/omermorad/nestjs-pact.svg?style=flat-square) [NestJS + Pact](https://www.npmjs.com/package/nestjs-pact) - Injectable Pact.js Consumer/Provider for NestJS
-- ![](https://img.shields.io/github/stars/omermorad/automock.svg?style=flat-square) [`@automock/jest`](https://github.com/omermorad/automock) - Standalone library for class-dependencies auto mocking
-- ![](https://img.shields.io/github/stars/suites-dev/suites.svg?style=flat-square) [`@suites/unit`](https://github.com/suites-dev/suites) - A progressive, flexible unit-testing framework for backend systems with dependency injection patterns, supporting NestJS, Jest, Vitest, and more
+- ![](https://img.shields.io/github/stars/suites-dev/suites.svg?style=flat-square) [Suites](https://github.com/suites-dev/suites) - Unit testing framework for TypeScript backends working with inversion of control (IoC) and dependency injection frameworks.
 
 ## Integrations
 


### PR DESCRIPTION
This PR updates the Suites entry in the Testing section:
- Changes link format to point directly to GitHub
- Updates description to: 'Unit testing framework for TypeScript backends working with inversion of control (IoC) and dependency injection frameworks.'
- Remove automock which Suites replaces

Per request from @omermorad