### PR TITLE
docs: add `@alpha018/nestjs-redisom` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@
 - [Nest Prisma](https://www.prisma.io/nestjs) - A Fully Type-Safe ORM for [NestJS](https://docs.nestjs.com/recipes/prisma).
 - ![](https://img.shields.io/github/stars/hyperloris/nestjs-tile38.svg?style=flat-square) [`nestjs-tile38`](https://github.com/hyperloris/nestjs-tile38) - A [Tile38](https://tile38.com) module for Nest framework.
 - ![](https://img.shields.io/github/stars/knaadh/nestjs-drizzle.svg?style=flat-square) [`nestjs-drizzle`](https://github.com/knaadh/nestjs-drizzle) - A [Drizzle ORM](https://orm.drizzle.team/) module for Nest.
+- ![](https://img.shields.io/github/stars/alpha018/nestjs-redisom.svg?style=flat-square) [`@alpha018/nestjs-redisom`](https://github.com/alpha018/nestjs-redisom) - A [RedisOM](https://redis.io/docs/latest/integrate/redisom-for-node-js/) module for NestJS, enabling object mapping and fluent query building for Redis.
 
 #### GraphQL
 


### PR DESCRIPTION
Include `@alpha018/nestjs-redisom`, a RedisOM module for NestJS, in the list of modules to enhance object mapping and fluent query building for Redis.

## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [x] Tutorial.
- [ ] Meetups.
- [x] Improve documentation _(grammatical corrections, improve doc style, ...)_.

## Description _(required)_

nestjs-redisom is a module that integrates Redis OM (Object Mapper) into the NestJS ecosystem. Its main objective is to facilitate the use of Redis not only as a cache, but as a fast and structured document database.

## Link _(required)_

https://github.com/Alpha018/nestjs-redisom
