### PR TITLE
Add @nestjs-redisx/* to Redis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@
 - ![](https://img.shields.io/github/stars/nest-modules/ioredis.svg?style=flat-square) [`@nestjs-modules/ioredis`](https://github.com/nest-modules/ioredis) - A ioredis module for Nest framework.
 - ![](https://img.shields.io/github/stars/liaoliaots/nestjs-redis.svg?style=flat-square) [`@liaoliaots/nestjs-redis`](https://github.com/liaoliaots/nestjs-redis) - Redis(ioredis) module for NestJS framework.
 - ![](https://img.shields.io/github/stars/csenshi/nestjs-redis.svg?style=flat-square) [`@csenshi/nestjs-redis`](https://github.com/CSenshi/nestjs-redis) - NestJS Redis toolkit for node-redis — Client, Redlock, health checks and more.
+- ![](https://img.shields.io/github/stars/nestjs-redisx/nestjs-redisx.svg?style=flat-square) [`@nestjs-redisx/*`](https://github.com/nestjs-redisx/nestjs-redisx) - Modular Redis toolkit with plugin architecture: L1+L2 caching (SWR, anti-stampede, tags), distributed locks, rate limiting, idempotency, streams, Prometheus metrics, and OpenTelemetry tracing.
 
 #### Mail
 


### PR DESCRIPTION
# Pull Request
## Type of Change
- [x] Adding a new resource

## Description
Adding NestJS RedisX to the Redis section — a modular Redis toolkit for NestJS with plugin architecture.

## Checklist
- [x] I have read the contribution guidelines
- [x] The resource I'm adding has at least 10 GitHub stars (if applicable)
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format

## Resource Details (if adding a new resource)
- **Name:** @nestjs-redisx/*
- **URL:** https://github.com/nestjs-redisx/nestjs-redisx
- **Category:** Components & Libraries > Redis
- **GitHub Stars (if applicable):** New project (v1.0.0 just launched)
- **Why is this resource valuable to the NestJS community?**
Provides a unified plugin-based approach to Redis in NestJS: L1+L2 caching with SWR and anti-stampede, distributed locks, rate limiting (3 algorithms), idempotency, Redis Streams, Prometheus metrics, and OpenTelemetry tracing. 8 packages, 2,200+ tests, supports both ioredis and node-redis.