### PR TITLE
Update Manifest entry with current project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@
 - [apitable](https://github.com/apitable/apitable) - APITable, an API-oriented low-code platform for building collaborative apps and better than all other Airtable open-source alternatives.
 - [Ghostfolio](https://github.com/ghostfolio/ghostfolio) - Ghostfolio is a privacy-focused, open-source dashboard that simplifies asset tracking and supports informed financial decisions.
 - [Twenty](https://github.com/twentyhq/twenty) - An open-source full-stack CRM system designed as an alternative to Salesforce for managing customer data and workflows efficiently.
-- [Manifest](https://manifest.build) - 1-file micro backend in YAML.
+- [Manifest](https://manifest.build) - Open-source real-time cost observability for AI agents. Built with NestJS 11, TypeORM, SQLite. Tracks tokens, costs, messages, model usage. Self-hostable, privacy-focused, OTLP-native. ([Source Code](https://github.com/mnfst/manifest)) `MIT`
 - [IdeaForge](https://github.com/chenxiaoyao6228/idea-forge) - A powerful document collaboration platform that combines Notion-like functionality with AI capabilities. It offers a seamless environment for real-time collaborative editing, AI-powered writing assistance, and intuitive document management.
 - [Bunnychess](https://github.com/pietrobassi/bunnychess) - Open-source, scalable chess server built with NestJS microservices and NATS JetStream.
 - [Hoppscotch](https://github.com/hoppscotch/hoppscotch) - Open source API development ecosystem with NestJS backend - alternative to Postman.


### PR DESCRIPTION
## Summary
- Updated the existing [Manifest](https://manifest.build) entry in the "Projects using NestJS > Open Source" section to reflect the project's current focus: open-source real-time cost observability for AI agents
- Added source code link ([GitHub](https://github.com/mnfst/manifest)) and MIT license badge
- Manifest is built with NestJS 11, TypeORM, and SQLite; it tracks tokens, costs, messages, and model usage; it is self-hostable, privacy-focused, and OTLP-native

## Test plan
- [ ] Verify the entry renders correctly in the README
- [ ] Confirm the website link (https://manifest.build) and source code link (https://github.com/mnfst/manifest) are valid