### PR TITLE
docs: add @horizon-republic/nestjs-jetstream to Microservice section

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@
 - ![](https://img.shields.io/github/stars/pvarentsov/nestjs-pg-notify.svg?style=flat-square) [`nestjs-pg-notify`](https://github.com/pvarentsov/nestjs-pg-notify) - NestJS custom transport strategy for PostgreSQL Pub/Sub.
 - ![](https://img.shields.io/github/stars/sergey-telpuk/nestjs-transport-eventbus.svg?style=flat-square) [`nestjs-transport-eventbus`](https://github.com/sergey-telpuk/nestjs-transport-eventbus) - The module for Nest to allow broadcasting events via variety of nestjs trasports in easy way
 - ![](https://img.shields.io/github/stars/p-fedyukovich/nestjs-google-pubsub-microservice.svg?style=flat-square) [`nestjs-google-pubsub-microservice`](https://github.com/p-fedyukovich/nestjs-google-pubsub-microservice) - Custom Google Cloud Pub/Sub microservice transport
+- ![](https://img.shields.io/github/stars/HorizonRepublic/nestjs-jetstream.svg?style=flat-square) [`@horizon-republic/nestjs-jetstream`](https://github.com/HorizonRepublic/nestjs-jetstream) - Drop-in NATS JetStream transport — persistent events, broadcast, ordered delivery, and RPC via standard NestJS patterns.
 
 #### Database
 


### PR DESCRIPTION
## Type of Change

- [x] Adding a new resource

## Description

Adds `@horizon-republic/nestjs-jetstream` to the Microservice section — a NATS JetStream transport with automatic stream/consumer management and four delivery modes (workqueue, broadcast, ordered, RPC). Uses standard @EventPattern/@MessagePattern decorators — no new API to learn. Includes dead letter handling, health checks, graceful shutdown, lifecycle hooks, and pluggable codecs.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/nestjs/awesome-nestjs/blob/master/CONTRIBUTING.md)
- [x] The resource I'm adding has **at least 10 GitHub stars**
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format

## Resource Details

- **Name:** @horizon-republic/nestjs-jetstream
- **URL:** https://github.com/HorizonRepublic/nestjs-jetstream
- **Category:** Components & Libraries > Microservice
- **Why is this resource valuable to the NestJS community?** Fills the gap for persistent NATS messaging in NestJS — the built-in transport only supports Core NATS (fire-and-forget).