### PR TITLE
docs: add nest-trpc-native to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@
 - ![](https://img.shields.io/github/stars/Fcmam5/nest-problem-details.svg?style=flat-square) [`nest-problem-details`](https://github.com/Fcmam5/nest-problem-details) An exception filter to return [RFC-7807](https://datatracker.ietf.org/doc/html/rfc7807)-compliant HTTP responses.
 - ![](https://img.shields.io/github/stars/woowabros/nestjs-library-crud.svg?style=flat-square) [`@nestjs-library/crud`](https://github.com/woowabros/nestjs-library-crud) - Automatically generates CRUD routes of a controller for given TypeORM entity.
 - ![](https://img.shields.io/github/stars/rbonestell/nest-ndjson-req-stream.svg?style=flat-square) [`nest-ndjson-req-stream`](https://github.com/rbonestell/nest-ndjson-req-stream) - Accept and automatically deserialize NDJSON request streams in NestJS
+- ![](https://img.shields.io/github/stars/rodrigobnogueira/nest-trpc-native.svg?style=flat-square) [`nest-trpc-native`](https://github.com/rodrigobnogueira/nest-trpc-native) - Native, decorator-first tRPC integration for NestJS. Build typesafe APIs with full support for Nest dependency injection, guards, and interceptors.
 
 #### Middleware
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Adding a new resource

## Description

Adds [`nest-trpc-native`](https://github.com/rodrigobnogueira/nest-trpc-native) to the **API** section under Components & Libraries.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource I'm adding has **at least 10 GitHub stars** (if applicable)
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format:
  - `- ![](star-badge-url) [Name](URL) - Description.`

## Resource Details

- **Name:** nest-trpc-native
- **URL:** https://github.com/rodrigobnogueira/nest-trpc-native
- **Category:** Components & Libraries > API
- **GitHub Stars:** 10
- **Why is this resource valuable to the NestJS community?** It provides a native, decorator-first tRPC integration for NestJS, allowing developers to build fully type-safe APIs while leveraging NestJS's dependency injection, guards, interceptors, and pipes — without leaving the familiar NestJS programming model.