### PR TITLE
docs: add nestjs-doctor to Lint section

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@
 
 - ![](https://img.shields.io/github/stars/unlight/eslint-plugin-nestjs.svg?style=flat-square) [`eslint-plugin-nestjs`](https://github.com/unlight/eslint-plugin-nestjs) - ESLint rules for NestJS framework.
 - ![](https://img.shields.io/github/stars/darraghoriordan/eslint-plugin-nestjs-typed.svg?style=flat-square) [`@darraghor/eslint-plugin-nestjs-typed`](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) - ESLint rules for NestJS framework.
+- ![](https://img.shields.io/github/stars/RoloBits/nestjs-doctor.svg?style=flat-square) [`nestjs-doctor`](https://github.com/RoloBits/nestjs-doctor) - Static analysis and diagnostics tool with health scores, module graph, endpoint dependency visualization, and schema analysis.
 
 #### Router🚦
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Adding a new resource

## Description

Adds [`nestjs-doctor`](https://github.com/RoloBits/nestjs-doctor) to the **Lint** section under Components & Libraries.

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource I'm adding has **at least 10 GitHub stars** (if applicable)
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format:
  - `- ![](star-badge-url) [Name](URL) - Description.`

## Resource Details

- **Name:** nestjs-doctor
- **URL:** https://github.com/RoloBits/nestjs-doctor
- **Category:** Components & Libraries > Lint
- **GitHub Stars:** 90
- **Why is this resource valuable to the NestJS community?** It provides a dedicated static analysis CLI and VSCode extension for NestJS projects covering 50+ lint rules for correctness, security, architecture, and performance, plus module graph visualization, endpoint dependency graphs, schema analysis, and a health score report. 