### PR TITLE
Add layercache to Cache section

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@
 #### Cache
 
 - [`@nestjs/cache-manager`](https://github.com/nestjs/cache-manager) - Official caching module for NestJS with support for multiple stores (Redis, Memcached, etc.).
+- ![](https://img.shields.io/github/stars/flyingsquirrel0419/layercache.svg?style=flat-square) [`@cachestack/nestjs`](https://github.com/flyingsquirrel0419/layercache/tree/main/packages/nestjs) - NestJS module for layercache, a multi-layer caching toolkit with memory/Redis/disk stores, stale serving, anti-stampede protection, tags, metrics, and distributed invalidation.
 - ![](https://img.shields.io/github/stars/BJS-kr/nestjs-omacache.svg?style=flat-square) [`nestjs-omacache`](https://github.com/BJS-kr/nestjs-omacache) - A simple, flexible and powerful cache decorator factory for NestJS framework.
 
 #### Redis

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@
 #### Cache
 
 - [`@nestjs/cache-manager`](https://github.com/nestjs/cache-manager) - Official caching module for NestJS with support for multiple stores (Redis, Memcached, etc.).
-- ![](https://img.shields.io/github/stars/flyingsquirrel0419/layercache.svg?style=flat-square) [`@cachestack/nestjs`](https://github.com/flyingsquirrel0419/layercache/tree/main/packages/nestjs) - NestJS module for layercache, a multi-layer caching toolkit with memory/Redis/disk stores, stale serving, anti-stampede protection, tags, metrics, and distributed invalidation.
+- ![](https://img.shields.io/github/stars/flyingsquirrel0419/layercache.svg?style=flat-square) [`layercache`](https://github.com/flyingsquirrel0419/layercache/tree/main/packages/nestjs) - NestJS module for multi-layer caching with memory/Redis/disk stores, stale serving, anti-stampede protection, tags, metrics, and distributed invalidation.
 - ![](https://img.shields.io/github/stars/BJS-kr/nestjs-omacache.svg?style=flat-square) [`nestjs-omacache`](https://github.com/BJS-kr/nestjs-omacache) - A simple, flexible and powerful cache decorator factory for NestJS framework.
 
 #### Redis


### PR DESCRIPTION
  ## Type of Change

  - [x] Adding a new resource
  - [ ] Updating an existing resource
  - [ ] Removing an outdated resource
  - [ ] Fixing a bug (broken link, typo, etc.)
  - [ ] Other (please describe)

  ## Description

  Add `layercache` to the **Cache** section as a NestJS-compatible multi-layer caching library with memory, Redis, and disk stores,
  plus stale serving, anti-stampede protection, tags, metrics, and distributed invalidation.

  ## Checklist

  Please ensure your PR meets the following requirements:

  - [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
  - [x] The resource I'm adding has **at least 10 GitHub stars** (if applicable)
  - [x] The link I'm adding is working and points to the correct resource
  - [x] I have placed the resource in the appropriate category
  - [x] The description is clear and concise
  - [x] I have followed the existing format:
    - `- [Name](URL) - Description.`
    - For libraries with star badges: `- ![](star-badge-url) [Name](URL) - Description.`

  ## Resource Details (if adding a new resource)

  - **Name:** `layercache`
  - **URL:** https://github.com/flyingsquirrel0419/layercache/tree/main/packages/nestjs
  - **Category:** Cache
  - **GitHub Stars (if applicable):** 12
  - **Why is this resource valuable to the NestJS community?**

 It provides a production-focused caching module for NestJS with support for multi-layer caching across memory, Redis, and disk.
It also includes features like stale-while-revalidate, anti-stampede protection, tag-based invalidation, distributed invalidation, and metrics, which are useful for real-world NestJS applications.

