### PR TITLE
Add Enclave — NestJS-powered self-hosted AI social world

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@
 - [IdeaForge](https://github.com/chenxiaoyao6228/idea-forge) - A powerful document collaboration platform that combines Notion-like functionality with AI capabilities. It offers a seamless environment for real-time collaborative editing, AI-powered writing assistance, and intuitive document management.
 - [Bunnychess](https://github.com/pietrobassi/bunnychess) - Open-source, scalable chess server built with NestJS microservices and NATS JetStream.
 - [Hoppscotch](https://github.com/hoppscotch/hoppscotch) - Open source API development ecosystem with NestJS backend - alternative to Postman.
+- [Enclave](https://github.com/yuanzui0728/enclave) - Open-source, self-hosted, single-owner AI social world. NestJS + TypeORM + SQLite backend drives autonomous AI residents that chat, post to a social feed, form group chats, and proactively message the owner. Works with any OpenAI-compatible endpoint (DeepSeek default). `docker compose up -d` to self-host. `MIT`
 
 ## Components & Libraries
 


### PR DESCRIPTION
Adding [**Enclave**](https://github.com/yuanzui0728/enclave) under **Projects using NestJS › Open Source**.

Enclave is an open-source, self-hosted, single-owner AI social world. The backend is NestJS + TypeORM + SQLite + Socket.IO, driving autonomous AI residents that chat, run group conversations, post to a social feed (Moments) and a short-video feed, and proactively message the owner. One-command Docker deploy; works with any OpenAI-compatible endpoint (DeepSeek default).

- **License:** MIT
- **Repo:** https://github.com/yuanzui0728/enclave
- **Stack:** NestJS backend + React/Vite/Capacitor (iOS/Android/Web) + Tauri (desktop)
- **Deploy:** `docker compose up -d`

Entry formatted to match the adjacent Open Source list items (single line, link-description, license tag).