### PR TITLE
Add `@abinnovision/nestjs-configx` to Components & Libraries Utilities section

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@
 - ![](https://img.shields.io/github/stars/unlight/prisma-nestjs-graphql?style=flat-square) [`prisma-nestjs-graphql`](https://github.com/unlight/prisma-nestjs-graphql) - Generate object types, inputs, args, etc. from prisma schema file for usage with `@nestjs/graphql` module.
 - ![](https://img.shields.io/github/stars/nestjstools/messaging?style=flat-square) [`@nestjstools/messaging`](https://github.com/nestjstools/messaging) - A NestJS library for managing asynchronous and synchronous messages (service bus | message bus) with support for buses, handlers, channels, and consumers.
 - ![](https://img.shields.io/github/stars/Akronae/nestjs-openapi-validation?style=flat-square) [`nestjs-openapi-validation`](https://github.com/Akronae/nestjs-openapi-validation) - Validate NestJS DTOs with Zod using TypeScript/OpenAPI spec.
+- ![](https://img.shields.io/github/stars/abinnovision/nestjs-commons.svg?style=flat-square) [`@abinnovision/nestjs-configx`](https://github.com/abinnovision/nestjs-commons/tree/main/packages/configx) - Simple configuration management for NestJS, supporting [Standard Schema](https://standardschema.dev/).
 
 #### Code Style
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Adding a new resource
- [ ] Updating an existing resource
- [ ] Removing an outdated resource
- [ ] Fixing a bug (broken link, typo, etc.)
- [ ] Other (please describe)

## Description

Adds [`@abinnovision/nestjs-configx`](https://github.com/abinnovision/nestjs-commons/tree/master/packages/configx) to the **Components & Libraries → Utilities** section. It is a simple configuration management module for NestJS with support for [Standard Schema](https://standardschema.dev/), letting you validate environment-driven configuration with any compatible validator (Zod, Valibot, ArkType, etc.).

## Checklist

Please ensure your PR meets the following requirements:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource I'm adding has **at least 10 GitHub stars** (if applicable)
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format:
  - `- [Name](URL) - Description.`
  - For libraries with star badges: `- ![](star-badge-url) [Name](URL) - Description.`

## Resource Details (if adding a new resource)

- **Name:** `@abinnovision/nestjs-configx`
- **URL:** https://github.com/abinnovision/nestjs-commons/tree/master/packages/configx
- **Category:** Components & Libraries → Utilities
- **GitHub Stars (if applicable):** 19 (shared monorepo `abinnovision/nestjs-commons`)
- **Why is this resource valuable to the NestJS community?** Provides a lightweight, type-safe configuration module built on the emerging [Standard Schema](https://standardschema.dev/) spec, so teams can plug in their preferred validator (Zod, Valibot, ArkType, …) without coupling configuration to a single library. It complements existing config options in the list by being schema-library-agnostic.

<!-- Thank you for contributing to Awesome NestJS! 🎉 -->