### PR TITLE
Add `@abinnovision/nestjs-healthz` to Components & Libraries Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@
 - ![](https://img.shields.io/github/stars/willsoto/nestjs-prometheus.svg?style=flat-square) [`nestjs-prometheus`](https://github.com/willsoto/nestjs-prometheus) - NestJS module for Prometheus.
 - ![](https://img.shields.io/github/stars/apitally/apitally-js.svg?style=flat-square) [`apitally`](https://github.com/apitally/apitally-js) - Client library for [Apitally](https://apitally.io/nestjs), a simple API monitoring & analytics tool with alerting for NestJS.
 - ![](https://img.shields.io/github/stars/netanelavr/nestjs-metrics-reporter.svg?style=flat-square) [`nestjs-metrics-reporter`](https://github.com/netanelavr/nestjs-metrics-reporter) - A zero-dependency-injection global metrics reporter for NestJS.
+- ![](https://img.shields.io/github/stars/abinnovision/nestjs-commons.svg?style=flat-square) [`@abinnovision/nestjs-healthz`](https://github.com/abinnovision/nestjs-commons/tree/main/packages/healthz) - Self-mounting health check module with cross-module attestor discovery and Kubernetes-style probes.
 
 #### Internationalization (i18n)
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Adding a new resource
- [ ] Updating an existing resource
- [ ] Removing an outdated resource
- [ ] Fixing a bug (broken link, typo, etc.)
- [ ] Other (please describe)

## Description

Adds [`@abinnovision/nestjs-healthz`](https://github.com/abinnovision/nestjs-commons/tree/main/packages/healthz) to the **Components & Libraries → Monitoring** section. It is a self-mounting health check module that auto-discovers attestors across modules and exposes Kubernetes-style liveness and readiness probes out of the box.

## Checklist

Please ensure your PR meets the following requirements:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource I'm adding has **at least 10 GitHub stars** (if applicable)
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format:
  - `- [Name](URL) - Description.`
  - For libraries with star badges: `- ![](star-badge-url) [Name](URL) - Description.`

## Resource Details (if adding a new resource)

- **Name:** `@abinnovision/nestjs-healthz`
- **URL:** https://github.com/abinnovision/nestjs-commons/tree/main/packages/healthz
- **Category:** Components & Libraries → Monitoring
- **GitHub Stars (if applicable):** 19 (shared monorepo `abinnovision/nestjs-commons`)
- **Why is this resource valuable to the NestJS community?** Provides a drop-in health check module purpose-built for Kubernetes-style liveness and readiness probes. Unlike manually wiring `@nestjs/terminus` indicators, attestors are auto-discovered across modules, so feature modules can contribute their own checks without the app module having to register them centrally.

<!-- Thank you for contributing to Awesome NestJS! 🎉 -->