### PR TITLE
Add @silkweave/nestjs to API section

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@
 - ![](https://img.shields.io/github/stars/woowabros/nestjs-library-crud.svg?style=flat-square) [`@nestjs-library/crud`](https://github.com/woowabros/nestjs-library-crud) - Automatically generates CRUD routes of a controller for given TypeORM entity.
 - ![](https://img.shields.io/github/stars/rbonestell/nest-ndjson-req-stream.svg?style=flat-square) [`nest-ndjson-req-stream`](https://github.com/rbonestell/nest-ndjson-req-stream) - Accept and automatically deserialize NDJSON request streams in NestJS
 - ![](https://img.shields.io/github/stars/rodrigobnogueira/nest-trpc-native.svg?style=flat-square) [`nest-trpc-native`](https://github.com/rodrigobnogueira/nest-trpc-native) - Native, decorator-first tRPC integration for NestJS. Build typesafe APIs with full support for Nest dependency injection, guards, and interceptors.
+- ![](https://img.shields.io/github/stars/silkweave/silkweave.svg?style=flat-square) [`@silkweave/nestjs`](https://github.com/silkweave/silkweave/tree/master/packages/nestjs) - Expose existing controllers as Model Context Protocol (MCP) tools with a single `@Mcp()` decorator, reflecting tool schemas from route, param, and DTO metadata.
 
 #### Middleware
 


### PR DESCRIPTION
## Resource type _(required)_

- [x] GitHub Repository:
    - [x] **(Required)** I confirm that the GitHub repository has more than **10 stars**.
    - [x] **(Required)** The repository is not archived.
- [ ] Video.
- [ ] Tutorial.
- [ ] Meetups.
- [ ] Improve documentation _(grammatical corrections, improve doc style, ...)_.

## Description _(required)_

`@silkweave/nestjs` exposes existing NestJS controllers as Model Context Protocol (MCP) tools by adding a single `@Mcp()` decorator to a route handler. The tool's name, description, and input schema are reflected from the route, the `@Param`/`@Query`/`@Body` decorators, and any `@nestjs/swagger` / `class-validator` metadata the method already carries — nothing is re-declared. It is additive: controllers keep serving HTTP exactly as before, and `@UseGuards()` guards run on tool calls too.

Added under **Components & Libraries → API**.

## Link _(required)_

https://github.com/silkweave/silkweave/tree/master/packages/nestjs

## Rules _(required)_

- [x] **NestJS / Nest**: It's not nest, nestjs, nest.js, and other variants.
- [x] **Node.js**: It's not nodejs, node, and other variants.
