### PR TITLE
Remove dead REST NestJS Postgres link

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@
 - [Domain Driven Design - Library](https://github.com/Sikora00/ddd-by-examples-library-nestjs) - Example of an application that follows Domain Driven Design.
 - [Realworld Example App](https://github.com/lujakob/nestjs-realworld-example-app) - Exemplary real world backend API built with NestJS + TypeORM.
 - [Mant](https://github.com/vladotesanovic/mant) - New Stack on the Market to beat them all :ring: MANT.
-- [REST NestJS Postgres](https://github.com/crudjs/rest-nestjs-postgres) - CrudJS implemented as a REST API, using NestJS and Postgres.
 - [Nest Permissions Seed](https://github.com/EndyKaufman/nest-permissions-seed) - A simple application demonstrating the basic usage of permissions with NestJS.
 - [Angular NestJS Rendering](https://github.com/Innovic-io/angular-nestjs-rendering) - Angular 5+ server side rendering using NestJS.
 - [Angular Contact Manager App](https://github.com/Abdallah-khalil/ContactManagerApp) - A Contact Manager App using Angular, NestJS, Mongoose, Passport, JWT.


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Removing an outdated resource
- [x] Fixing a bug (broken link, typo, etc.)

## Description

Removed the defunct [REST NestJS Postgres](https://github.com/crudjs/rest-nestjs-postgres) repository (permanently returns a 404 error).

## Checklist

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The description is clear and concise
