### PR TITLE
Add `@stitchapi/nest` to Components & Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@
 - ![](https://img.shields.io/github/stars/nestjstools/messaging?style=flat-square) [`@nestjstools/messaging`](https://github.com/nestjstools/messaging) - A NestJS library for managing asynchronous and synchronous messages (service bus | message bus) with support for buses, handlers, channels, and consumers.
 - ![](https://img.shields.io/github/stars/Akronae/nestjs-openapi-validation?style=flat-square) [`nestjs-openapi-validation`](https://github.com/Akronae/nestjs-openapi-validation) - Validate NestJS DTOs with Zod using TypeScript/OpenAPI spec.
 - ![](https://img.shields.io/github/stars/abinnovision/nestjs-commons.svg?style=flat-square) [`@abinnovision/nestjs-configx`](https://github.com/abinnovision/nestjs-commons/tree/main/packages/configx) - Simple configuration management for NestJS, supporting [Standard Schema](https://standardschema.dev/).
+- ![](https://img.shields.io/github/stars/rejifald/StitchAPI.svg?style=flat-square) [`@stitchapi/nest`](https://github.com/rejifald/StitchAPI/tree/main/packages/nest) - Injectable, typed and schema-validated HTTP clients with streaming, retries, throttling and caching, plus Logger and ConfigService bridges, an exception filter and an SSE bridge.
 
 #### Code Style
 


### PR DESCRIPTION
# Pull Request

## Type of Change

- [x] Adding a new resource
- [ ] Updating an existing resource
- [ ] Removing an outdated resource
- [ ] Fixing a bug (broken link, typo, etc.)
- [ ] Other (please describe)

## Description

Adds `@stitchapi/nest` to **Components & Libraries → Utilities**.

`StitchModule.forRoot`/`forRootAsync` wires a shared store and trace sink into Nest's DI graph; `forFeature` + `defineStitch` register injectable, typed HTTP clients per feature module, each free to carry its own upstream `baseUrl` and auth. Responses are validated against any [Standard Schema](https://standardschema.dev) validator (Zod, Valibot, ArkType, …) — none is bundled — and the same client covers streaming, retries, throttling and caching.

It also ships the Nest-side bridges you would otherwise hand-roll: a `Logger` trace sink, a `ConfigService` secret resolver, an exception filter, and an SSE bridge for `@Sse()` endpoints.

I put it in Utilities next to `nestjs-http-promise` rather than under API, since it is an outbound client for calling other services — it does not shape your own routes or generate a spec.

One note that will save you a click: the Awesome Lint job is already red on `master` (52 errors, mostly missing trailing periods and the license section). I ran `awesome-lint` locally before and after this change — the count is 52 either way, so the new line adds no violations.

## Checklist

Please ensure your PR meets the following requirements:

- [x] I have read the [contribution guidelines](../CONTRIBUTING.md)
- [x] The resource I'm adding has **at least 10 GitHub stars** (if applicable)
- [x] The link I'm adding is working and points to the correct resource
- [x] I have placed the resource in the appropriate category
- [x] The description is clear and concise
- [x] I have followed the existing format:
  - `- [Name](URL) - Description.`
  - For libraries with star badges: `- ![](star-badge-url) [Name](URL) - Description.`

## Resource Details (if adding a new resource)

- **Name:** `@stitchapi/nest`
- **URL:** https://github.com/rejifald/StitchAPI/tree/main/packages/nest
- **Category:** Components & Libraries → Utilities
- **GitHub Stars (if applicable):** 11
- **Why is this resource valuable to the NestJS community?** Outbound HTTP is the one place Nest stays deliberately thin — `@nestjs/axios` gives you a client and leaves validation, retries, throttling, caching, streaming and tracing to interceptors everyone rewrites. This collapses that into one injectable, schema-validated client that respects DI, config and lifecycle hooks instead of sitting beside them.

<!-- Requirements from the alternate template in .github/, since the repo carries two: -->

- [x] The repository has more than **10 stars**.
- [x] The repository is not archived.
- [x] **NestJS / Nest**: it's not nest, nestjs, nest.js, or other variants.
- [x] **Node.js**: it's not nodejs, node, or other variants.
