### PR TITLE
Add `eslint-plugin-nestjs-security` to Lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@
 - ![](https://img.shields.io/github/stars/unlight/eslint-plugin-nestjs.svg?style=flat-square) [`eslint-plugin-nestjs`](https://github.com/unlight/eslint-plugin-nestjs) - ESLint rules for NestJS framework.
 - ![](https://img.shields.io/github/stars/darraghoriordan/eslint-plugin-nestjs-typed.svg?style=flat-square) [`@darraghor/eslint-plugin-nestjs-typed`](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) - ESLint rules for NestJS framework.
 - ![](https://img.shields.io/github/stars/RoloBits/nestjs-doctor.svg?style=flat-square) [`nestjs-doctor`](https://github.com/RoloBits/nestjs-doctor) - Static analysis and diagnostics tool with health scores, module graph, endpoint dependency visualization, and schema analysis.
+- ![](https://img.shields.io/github/stars/ofri-peretz/eslint.svg?style=flat-square) [`eslint-plugin-nestjs-security`](https://github.com/ofri-peretz/eslint/tree/main/packages/eslint-plugin-nestjs-security) - Security-focused ESLint rules for controllers and DTOs: missing guards, throttling and validation pipes, exposed private fields and debug endpoints.
 
 #### Router🚦
 


### PR DESCRIPTION
Adds `eslint-plugin-nestjs-security` to the **Lint** section.

It's a set of security-focused ESLint rules for NestJS controllers and DTOs — six rules covering missing guards, missing throttling, missing validation pipes, `@Exclude`-less private fields on serialized entities, and debug endpoints left exposed on a controller or route.

It complements the two entries already in that section rather than overlapping them: `eslint-plugin-nestjs` and `@darraghor/eslint-plugin-nestjs-typed` cover convention and typing correctness, while these rules only look for security-relevant gaps.

Disclosure: I maintain it.

**Checklist against CONTRIBUTING.md**

- [x] Searched existing entries — no duplicate
- [x] Actively maintained (published today; the repo was pushed to today)
- [x] Links working
- [x] Documentation — per-rule docs with CWE/CVSS mappings
- [x] ≥ 10 GitHub stars (12)
- [x] Relevant to NestJS, English, MIT-licensed and free
- [x] Entry format — star badge + backticked package name + one sentence starting with a capital and ending with a period; description avoids repeating "NestJS" per the guidelines